### PR TITLE
fix: regex updated to match new fb messenger conversation id

### DIFF
--- a/src/ChatUploader.js
+++ b/src/ChatUploader.js
@@ -24,7 +24,7 @@ const getFileProvider = async (file) => {
 }
 
 const parseFacebookChats = async (zip) => {
-  const regex = /messages\/[a-z_]+\/[a-z0-9_]+\/[a-z0-9_]+\.json/g
+  const regex = /messages\/[a-z_]+\/[a-z0-9_-]+\/[a-z0-9_-]+\.json/g
   const files = Object.keys(zip.files).filter((f) => regex.test(f))
   const texts = await Promise.all(files.map((f) => zip.file(f).async('string')))
   const json = texts.map((t) => JSON.parse(t))


### PR DESCRIPTION
Updated the regex used to find all .json files in the messages folder in order to match the new format on messenger conversation ids.

Old regex did not match this folder name 'personname_g1-a0nzknh' inside the messages folder causing the conversation(chat) to not show, so I modified it in order to match this new one and old one.